### PR TITLE
Cycomp patch 1

### DIFF
--- a/main.js
+++ b/main.js
@@ -229,9 +229,6 @@ function findMatchingEndpoint(point, thisPiece, allPieces) {
   return matches.length === 1 ? matches[0] : null;;
 }
 
-  const viewport = document.getElementById('viewport')
-  const transform = viewport.transform.baseVal.consolidate()?.matrix;
-
 
 function getTransformedEndpoint(g, point) {
   const svg = document.getElementById('editor');


### PR DESCRIPTION
Changed starting values for bounding box comparisons to negative infinity as the grid now extends below (0,0)
Removed unused variables for a piece bounding box